### PR TITLE
shapes: v2: add SHACL shapes for new RML ontology

### DIFF
--- a/shapes/v2/execution.ttl
+++ b/shapes/v2/execution.ttl
@@ -1,0 +1,75 @@
+###############################################################################
+# RMLF Execution shape                                                        #
+# Copyright Dylan Van Assche, IDLab - UGent - imec (2023)                     #
+###############################################################################
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix schema: <http://schema.org/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rml: <http://w3id.org/rml/core/> .
+@prefix rmlf: <http://w3id.org/rml/fnml/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> . 
+
+schema:RMLFExecutionShape
+    a sh:NodeShape ;
+    sh:ignoredProperties (rdf:type) ;
+    sh:name "rmlf:ExecutionMap" ;
+    sh:description """
+    Represents a Execution.
+    """ ;
+
+    # Exactly one rmlf:function or rmlf:functionMap is required 
+    sh:property [
+        sh:path [sh:alternativePath (rmlf:function 
+                                     rmlf:functionMap)] ;
+        sh:name "rmlf:function/rmlf:functionMap" ;
+        sh:description """
+        Exactly one rmlf:function or rmlf:functionMap is required.
+        """ ;
+        sh:message """
+        Exactly one rmlf:function or rmlf:functionMap is required.
+        """ ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+    ] ;
+
+    # rmlf:functionMap non-shortcut
+    sh:property [
+        sh:path rmlf:functionMap ;
+        sh:name "rmlf:functionMap" ;
+        sh:description """
+        FnO function to execute.
+        """ ;
+        sh:message """
+        rmlf:functionMap must be an IRI or Blank node.
+        """ ;
+        sh:nodeKind sh:BlankNodeOrIRI ;
+        sh:node schema:RMLFFunctionMap;
+    ] ;
+
+    # rmlf:function shortcut
+    sh:property [
+        sh:path rmlf:function ;
+        sh:name "rmlf:function" ;
+        sh:description """
+        FnO function to execute.
+        """ ;
+        sh:message """
+        rmlf:function must be an IRI.
+        """ ;
+        sh:nodeKind sh:IRI ;
+    ] ;
+
+    # rmlf:input
+    sh:property [
+        sh:path rmlf:input ;
+        sh:name "rmlf:input" ;
+        sh:description """
+        Input parameters for the function.
+        """ ;
+        sh:message """
+        rmlf:input must be a IRI, provided once.
+        """ ;
+        sh:maxCount 1 ;
+        sh:nodeKind sh:IRI ;
+    ] ;
+.

--- a/shapes/v2/fnml.ttl
+++ b/shapes/v2/fnml.ttl
@@ -1,0 +1,253 @@
+@prefix owl: <http://www.w3.org/2002/07/owl#> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rdfs: <http://www.w3.org/2000/01/rdf-schema#> .
+@prefix rml: <http://w3id.org/rml/core/> .
+@prefix rmlf: <http://w3id.org/rml/fnml/> .
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix xml: <http://www.w3.org/XML/1998/namespace> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> .
+
+<http://schema.org/RMLFExecutionShape> a sh:NodeShape ;
+    sh:description """
+    Represents a Execution.
+    """ ;
+    sh:ignoredProperties ( rdf:type ) ;
+    sh:name "rmlf:ExecutionMap" ;
+    sh:property [ sh:description """
+        Exactly one rmlf:function or rmlf:functionMap is required.
+        """ ;
+            sh:maxCount 1 ;
+            sh:message """
+        Exactly one rmlf:function or rmlf:functionMap is required.
+        """ ;
+            sh:minCount 1 ;
+            sh:name "rmlf:function/rmlf:functionMap" ;
+            sh:path [ sh:alternativePath ( rmlf:function rmlf:functionMap ) ] ],
+        [ sh:description """
+        FnO function to execute.
+        """ ;
+            sh:message """
+        rmlf:functionMap must be an IRI or Blank node.
+        """ ;
+            sh:name "rmlf:functionMap" ;
+            sh:node <http://schema.org/RMLFFunctionMap> ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:path rmlf:functionMap ],
+        [ sh:description """
+        FnO function to execute.
+        """ ;
+            sh:message """
+        rmlf:function must be an IRI.
+        """ ;
+            sh:name "rmlf:function" ;
+            sh:nodeKind sh:IRI ;
+            sh:path rmlf:function ],
+        [ sh:description """
+        Input parameters for the function.
+        """ ;
+            sh:maxCount 1 ;
+            sh:message """
+        rmlf:input must be a IRI, provided once.
+        """ ;
+            sh:name "rmlf:input" ;
+            sh:nodeKind sh:IRI ;
+            sh:path rmlf:input ] .
+
+<http://schema.org/RMLFFunctionMapShape> a sh:NodeShape ;
+    sh:description """
+    Represents a function map.
+    """ ;
+    sh:ignoredProperties ( rdf:type ) ;
+    sh:name "rmlf:FunctionMap" ;
+    sh:property [ sh:description """
+        A property for indicating whether a term map is a constant-valued term 
+        map.
+        """ ;
+            sh:message """
+        rml:constant must be an IRI.
+        """ ;
+            sh:name "rml:constant" ;
+            sh:nodeKind sh:IRI ;
+            sh:path rml:constant ],
+        [ sh:description """
+        An IRI indicating whether subject or object generated using the value 
+        from column name specified should be an IRI reference, blank node,
+        or a Literal.
+        """ ;
+            sh:in ( rml:IRI ) ;
+            sh:maxCount 1 ;
+            sh:message """
+        rml:termType must be either rml:IRI for an rmlf:ReturnMap.
+        May only be provided once.
+        """ ;
+            sh:name "rml:termType" ;
+            sh:nodeKind sh:IRI ;
+            sh:path rml:termType ],
+        [ sh:description """
+        A logical target is any target to where generated RDF triples are
+        exported to.
+        """ ;
+            sh:maxCount 1 ;
+            sh:message """
+        Zero or one rml:logicalTarget is required to export RDF triples.
+        """ ;
+            sh:minCount 0 ;
+            sh:name "rml:logicalTarget" ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:path rml:logicalTarget ] .
+
+<http://schema.org/RMLFInputShape> a sh:NodeShape ;
+    sh:description """
+    Represents an Input for a function.
+    """ ;
+    sh:ignoredProperties ( rdf:type ) ;
+    sh:name "rmlf:Input" ;
+    sh:property [ sh:description """
+        Values of the parameters.
+        """ ;
+            sh:maxCount 1 ;
+            sh:message """
+        rmlf:valueMap must be an IRI or Blank node, provided once.
+        """ ;
+            sh:name "rmlf:valueMap" ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:path rmlf:valueMap ],
+        [ sh:datatype xsd:string ;
+            sh:description """
+        Parameters to supply to FnO function.
+        """ ;
+            sh:maxCount 1 ;
+            sh:message """
+        rmlf:value must be a string Literal.
+        """ ;
+            sh:name "rmlf:value" ;
+            sh:nodeKind sh:Literal ;
+            sh:path rmlf:value ],
+        [ sh:description """
+        Exactly one rmlf:parameter or rmlf:parameterMap is required.
+        """ ;
+            sh:maxCount 1 ;
+            sh:message """
+        Exactly one rmlf:parameter or rmlf:parameterMap is required.
+        """ ;
+            sh:minCount 1 ;
+            sh:name "rmlf:parameter/rmlf:parameterMap" ;
+            sh:path [ sh:alternativePath ( rmlf:parameter rmlf:parameterMap ) ] ],
+        [ sh:description """
+        Parameters to supply to FnO function.
+        """ ;
+            sh:maxCount 1 ;
+            sh:message """
+        rmlf:parameterMap must be an IRI or Blank node.
+        """ ;
+            sh:name "rmlf:parameterMap" ;
+            sh:node <http://schema.org/RMLFParameterMap> ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:path rmlf:parameterMap ],
+        [ sh:description """
+        Parameters to supply to FnO function.
+        """ ;
+            sh:maxCount 1 ;
+            sh:message """
+        rmlf:parameter must be an IRI.
+        """ ;
+            sh:name "rmlf:parameter" ;
+            sh:nodeKind sh:IRI ;
+            sh:path rmlf:parameter ],
+        [ sh:description """
+        Exactly one rmlf:value or rmlf:valueMap is required.
+        """ ;
+            sh:maxCount 1 ;
+            sh:message """
+        Exactly one rmlf:value or rmlf:valueMap is required.
+        """ ;
+            sh:minCount 1 ;
+            sh:name "rmlf:value/rmlf:valueMap" ;
+            sh:path [ sh:alternativePath ( rmlf:value rmlf:valueMap ) ] ] .
+
+<http://schema.org/RMLFParameterMapShape> a sh:NodeShape ;
+    sh:description """
+    Represents a paramter map of a function.
+    """ ;
+    sh:ignoredProperties ( rdf:type ) ;
+    sh:name "rmlf:ParameterMap" ;
+    sh:property [ sh:description """
+        A property for indicating whether a term map is a constant-valued term 
+        map.
+        """ ;
+            sh:message """
+        rml:constant must be an IRI.
+        """ ;
+            sh:name "rml:constant" ;
+            sh:nodeKind sh:IRI ;
+            sh:path rml:constant ],
+        [ sh:description """
+        An IRI indicating whether subject or object generated using the value 
+        from column name specified should be an IRI reference, blank node,
+        or a Literal.
+        """ ;
+            sh:in ( rml:IRI ) ;
+            sh:maxCount 1 ;
+            sh:message """
+        rml:termType must be either rml:IRI for an rmlf:ReturnMap.
+        May only be provided once.
+        """ ;
+            sh:name "rml:termType" ;
+            sh:nodeKind sh:IRI ;
+            sh:path rml:termType ],
+        [ sh:description """
+        A logical target is any target to where generated RDF triples are
+        exported to.
+        """ ;
+            sh:maxCount 1 ;
+            sh:message """
+        Zero or one rml:logicalTarget is required to export RDF triples.
+        """ ;
+            sh:minCount 0 ;
+            sh:name "rml:logicalTarget" ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:path rml:logicalTarget ] .
+
+<http://schema.org/RMLFReturnMapShape> a sh:NodeShape ;
+    sh:description """
+    Represents a return map.
+    """ ;
+    sh:ignoredProperties ( rdf:type ) ;
+    sh:name "rmlf:ReturnMap" ;
+    sh:property [ sh:description """
+        A property for indicating whether a term map is a constant-valued term 
+        map.
+        """ ;
+            sh:message """
+        rml:constant must be an IRI.
+        """ ;
+            sh:name "rml:constant" ;
+            sh:nodeKind sh:IRI ;
+            sh:path rml:constant ],
+        [ sh:description """
+        An IRI indicating whether subject or object generated using the value 
+        from column name specified should be an IRI reference, blank node,
+        or a Literal.
+        """ ;
+            sh:in ( rml:IRI ) ;
+            sh:maxCount 1 ;
+            sh:message """
+        rml:termType must be either rml:IRI for an rmlf:ReturnMap.
+        May only be provided once.
+        """ ;
+            sh:name "rml:termType" ;
+            sh:nodeKind sh:IRI ;
+            sh:path rml:termType ],
+        [ sh:description """
+        A logical target is any target to where generated RDF triples are
+        exported to.
+        """ ;
+            sh:maxCount 1 ;
+            sh:message """
+        Zero or one rml:logicalTarget is required to export RDF triples.
+        """ ;
+            sh:minCount 0 ;
+            sh:name "rml:logicalTarget" ;
+            sh:nodeKind sh:BlankNodeOrIRI ;
+            sh:path rml:logicalTarget ] .
+

--- a/shapes/v2/function_map.ttl
+++ b/shapes/v2/function_map.ttl
@@ -1,0 +1,67 @@
+###############################################################################
+# RMLF Function Map shape                                                     #
+# Copyright Dylan Van Assche, IDLab - UGent - imec (2023)                     #
+###############################################################################
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix schema: <http://schema.org/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rml: <http://w3id.org/rml/core/> .
+@prefix rmlf: <http://w3id.org/rml/fnml/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> . 
+
+schema:RMLFFunctionMapShape
+    a sh:NodeShape ;
+    sh:ignoredProperties (rdf:type) ;
+    sh:name "rmlf:FunctionMap" ;
+    sh:description """
+    Represents a function map.
+    """ ;
+
+    # rml:constant
+    sh:property [
+        sh:path rml:constant ;
+        sh:name "rml:constant" ;
+        sh:description """
+        A property for indicating whether a term map is a constant-valued term 
+        map.
+        """ ;
+        sh:message """
+        rml:constant must be an IRI.
+        """ ;
+        sh:nodeKind sh:IRI ;
+    ] ;
+
+    # rml:termType
+    sh:property [
+        sh:path rml:termType ;
+        sh:name "rml:termType" ;
+        sh:description """
+        An IRI indicating whether subject or object generated using the value 
+        from column name specified should be an IRI reference, blank node,
+        or a Literal.
+        """ ;
+        sh:message """
+        rml:termType must be either rml:IRI for an rmlf:ReturnMap.
+        May only be provided once.
+        """ ;
+        sh:maxCount 1 ;
+        sh:in (rml:IRI) ;
+        sh:nodeKind sh:IRI ;
+    ] ;
+
+    # rml:logicalTarget
+    sh:property [
+        sh:path rml:logicalTarget ;
+        sh:name "rml:logicalTarget" ;
+        sh:description """
+        A logical target is any target to where generated RDF triples are
+        exported to.
+        """ ;
+        sh:message """
+        Zero or one rml:logicalTarget is required to export RDF triples.
+        """ ;
+        sh:nodeKind sh:BlankNodeOrIRI ;
+        sh:minCount 0 ;
+        sh:maxCount 1 ;
+    ] ;
+.

--- a/shapes/v2/generate_shape.py
+++ b/shapes/v2/generate_shape.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python
+
+import argparse
+import sys
+from os import path
+from glob import glob
+from rdflib import Graph, Namespace
+from rdflib.plugins.serializers.turtle import TurtleSerializer
+from rdflib import plugin
+
+SUBSHAPE_FORMAT = 'turtle'
+SUBSHAPE_GLOB_PATTERN = '*.ttl'
+SHACL = Namespace('http://www.w3.org/ns/shacl#')
+RML = Namespace('http://w3id.org/rml/core/')
+RMLF = Namespace('http://w3id.org/rml/fnml/')
+
+
+class TurtleWithPrefixes(TurtleSerializer):
+    """
+    A turtle serializer that always emits prefixes
+    Workaround for https://github.com/RDFLib/rdflib/issues/1048
+    """
+    roundtrip_prefixes = True  # Undocumented, forces to write all prefixes
+
+
+class ShapeGenerator:
+    """
+    Generates a complete SHACL shape of all the SHACL subshapes.
+    Useful for using the shapes in the shacl.org Playground.
+    """
+    def __init__(self, glob_pattern: str, rdf_format: str,
+                 destination: str) -> None:
+        self._glob_pattern: str = glob_pattern
+        self._rdf_format: str = rdf_format
+        self._destination: str = destination
+        self._shape = Graph()
+        self._shape.bind('sh', SHACL)
+        self._shape.bind('rml', RML)
+        self._shape.bind('rmlf', RMLF)
+        # Register TurtleWithPrefixes serializer as 'tortoise' format
+        plugin.register('tortoise',
+                        plugin.Serializer,
+                        'generate_shape',
+                        'TurtleWithPrefixes')
+
+    def generate(self) -> None:
+        """
+        Generate a full shape from the sub shapes.
+        """
+        print('Reading subshapes:')
+        for sub_shape in glob(self._glob_pattern):
+            if 'fnml.ttl' in sub_shape:
+                continue
+            print(f"\t{sub_shape}")
+            g = Graph()
+            g.bind('sh', SHACL)
+            g.bind('rml', RML)
+            g.bind('rmlf', RMLF)
+            self._shape += g.parse(sub_shape, format=self._rdf_format)
+
+        print(f'Writing shape to {self._destination}')
+        self._shape.serialize(destination=self._destination, format='tortoise')
+
+
+if __name__ == '__main__':
+    p = argparse.ArgumentParser(description='Generate a complete SHACL shape '
+                                'from the subshapes.')
+    p.add_argument('destination', type=str, help='Location to write the '
+                   'complete SHACL shape as Turtle.')
+    # Arguments parsing
+    args = p.parse_args()
+    if not path.exists(args.destination):
+        print(f'{args.destination} file path does not exist!')
+        sys.exit(1)
+
+    if path.isdir(args.destination):
+        args.destination = path.join(args.destination, 'fnml.ttl')
+
+    # Generate shape
+    generator = ShapeGenerator(SUBSHAPE_GLOB_PATTERN, SUBSHAPE_FORMAT,
+                               args.destination)
+    generator.generate()

--- a/shapes/v2/input.ttl
+++ b/shapes/v2/input.ttl
@@ -1,0 +1,107 @@
+###############################################################################
+# RMLF Input shape                                                            #
+# Copyright Dylan Van Assche, IDLab - UGent - imec (2023)                     #
+###############################################################################
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix schema: <http://schema.org/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rml: <http://w3id.org/rml/core/> .
+@prefix rmlf: <http://w3id.org/rml/fnml/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> . 
+
+schema:RMLFInputShape
+    a sh:NodeShape ;
+    sh:ignoredProperties (rdf:type) ;
+    sh:name "rmlf:Input" ;
+    sh:description """
+    Represents an Input for a function.
+    """ ;
+
+    # Exactly one rmlf:parameter or rmlf:parameterMap is required 
+    sh:property [
+        sh:path [sh:alternativePath (rmlf:parameter 
+                                     rmlf:parameterMap)] ;
+        sh:name "rmlf:parameter/rmlf:parameterMap" ;
+        sh:description """
+        Exactly one rmlf:parameter or rmlf:parameterMap is required.
+        """ ;
+        sh:message """
+        Exactly one rmlf:parameter or rmlf:parameterMap is required.
+        """ ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+    ] ;
+
+    # rmlf:parameterMap non-shortcut
+    sh:property [
+        sh:path rmlf:parameterMap ;
+        sh:name "rmlf:parameterMap" ;
+        sh:description """
+        Parameters to supply to FnO function.
+        """ ;
+        sh:message """
+        rmlf:parameterMap must be an IRI or Blank node.
+        """ ;
+        sh:nodeKind sh:BlankNodeOrIRI ;
+        sh:node schema:RMLFParameterMap;
+        sh:maxCount 1 ;
+    ] ;
+
+    # rmlf:parameter shortcut
+    sh:property [
+        sh:path rmlf:parameter ;
+        sh:name "rmlf:parameter" ;
+        sh:description """
+        Parameters to supply to FnO function.
+        """ ;
+        sh:message """
+        rmlf:parameter must be an IRI.
+        """ ;
+        sh:nodeKind sh:IRI ;
+        sh:maxCount 1 ;
+    ] ;
+
+    # Exactly one rmlf:value or rmlf:valueMap is required 
+    sh:property [
+        sh:path [sh:alternativePath (rmlf:value 
+                                     rmlf:valueMap)] ;
+        sh:name "rmlf:value/rmlf:valueMap" ;
+        sh:description """
+        Exactly one rmlf:value or rmlf:valueMap is required.
+        """ ;
+        sh:message """
+        Exactly one rmlf:value or rmlf:valueMap is required.
+        """ ;
+        sh:minCount 1 ;
+        sh:maxCount 1 ;
+    ] ;
+
+    # rmlf:valueMap
+    sh:property [
+        sh:path rmlf:valueMap ;
+        sh:name "rmlf:valueMap" ;
+        sh:description """
+        Values of the parameters.
+        """ ;
+        sh:message """
+        rmlf:valueMap must be an IRI or Blank node, provided once.
+        """ ;
+        sh:maxCount 1 ;
+        sh:nodeKind sh:BlankNodeOrIRI ;
+    ] ;
+
+    # rmlf:value shortcut
+    sh:property [
+        sh:path rmlf:value ;
+        sh:name "rmlf:value" ;
+        sh:description """
+        Parameters to supply to FnO function.
+        """ ;
+        sh:message """
+        rmlf:value must be a string Literal.
+        """ ;
+        sh:nodeKind sh:Literal ;
+        sh:datatype xsd:string ;
+        sh:maxCount 1 ;
+    ] ;
+.

--- a/shapes/v2/parameter_map.ttl
+++ b/shapes/v2/parameter_map.ttl
@@ -1,0 +1,67 @@
+###############################################################################
+# RMLF Parameter Map shape                                                    #
+# Copyright Dylan Van Assche, IDLab - UGent - imec (2023)                     #
+###############################################################################
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix schema: <http://schema.org/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rml: <http://w3id.org/rml/core/> .
+@prefix rmlf: <http://w3id.org/rml/fnml/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> . 
+
+schema:RMLFParameterMapShape
+    a sh:NodeShape ;
+    sh:ignoredProperties (rdf:type) ;
+    sh:name "rmlf:ParameterMap" ;
+    sh:description """
+    Represents a paramter map of a function.
+    """ ;
+
+    # rml:constant
+    sh:property [
+        sh:path rml:constant ;
+        sh:name "rml:constant" ;
+        sh:description """
+        A property for indicating whether a term map is a constant-valued term 
+        map.
+        """ ;
+        sh:message """
+        rml:constant must be an IRI.
+        """ ;
+        sh:nodeKind sh:IRI ;
+    ] ;
+
+    # rml:termType
+    sh:property [
+        sh:path rml:termType ;
+        sh:name "rml:termType" ;
+        sh:description """
+        An IRI indicating whether subject or object generated using the value 
+        from column name specified should be an IRI reference, blank node,
+        or a Literal.
+        """ ;
+        sh:message """
+        rml:termType must be either rml:IRI for an rmlf:ReturnMap.
+        May only be provided once.
+        """ ;
+        sh:maxCount 1 ;
+        sh:in (rml:IRI) ;
+        sh:nodeKind sh:IRI ;
+    ] ;
+
+    # rml:logicalTarget
+    sh:property [
+        sh:path rml:logicalTarget ;
+        sh:name "rml:logicalTarget" ;
+        sh:description """
+        A logical target is any target to where generated RDF triples are
+        exported to.
+        """ ;
+        sh:message """
+        Zero or one rml:logicalTarget is required to export RDF triples.
+        """ ;
+        sh:nodeKind sh:BlankNodeOrIRI ;
+        sh:minCount 0 ;
+        sh:maxCount 1 ;
+    ] ;
+.

--- a/shapes/v2/return_map.ttl
+++ b/shapes/v2/return_map.ttl
@@ -1,0 +1,67 @@
+###############################################################################
+# RMLF Return Map shape                                                       #
+# Copyright Dylan Van Assche, IDLab - UGent - imec (2023)                     #
+###############################################################################
+@prefix sh: <http://www.w3.org/ns/shacl#> .
+@prefix schema: <http://schema.org/> .
+@prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#> .
+@prefix rml: <http://w3id.org/rml/core/> .
+@prefix rmlf: <http://w3id.org/rml/fnml/> .
+@prefix xsd: <http://www.w3.org/2001/XMLSchema#> . 
+
+schema:RMLFReturnMapShape
+    a sh:NodeShape ;
+    sh:ignoredProperties (rdf:type) ;
+    sh:name "rmlf:ReturnMap" ;
+    sh:description """
+    Represents a return map.
+    """ ;
+
+    # rml:constant
+    sh:property [
+        sh:path rml:constant ;
+        sh:name "rml:constant" ;
+        sh:description """
+        A property for indicating whether a term map is a constant-valued term 
+        map.
+        """ ;
+        sh:message """
+        rml:constant must be an IRI.
+        """ ;
+        sh:nodeKind sh:IRI ;
+    ] ;
+
+    # rml:termType
+    sh:property [
+        sh:path rml:termType ;
+        sh:name "rml:termType" ;
+        sh:description """
+        An IRI indicating whether subject or object generated using the value 
+        from column name specified should be an IRI reference, blank node,
+        or a Literal.
+        """ ;
+        sh:message """
+        rml:termType must be either rml:IRI for an rmlf:ReturnMap.
+        May only be provided once.
+        """ ;
+        sh:maxCount 1 ;
+        sh:in (rml:IRI) ;
+        sh:nodeKind sh:IRI ;
+    ] ;
+
+    # rml:logicalTarget
+    sh:property [
+        sh:path rml:logicalTarget ;
+        sh:name "rml:logicalTarget" ;
+        sh:description """
+        A logical target is any target to where generated RDF triples are
+        exported to.
+        """ ;
+        sh:message """
+        Zero or one rml:logicalTarget is required to export RDF triples.
+        """ ;
+        sh:nodeKind sh:BlankNodeOrIRI ;
+        sh:minCount 0 ;
+        sh:maxCount 1 ;
+    ] ;
+.


### PR DESCRIPTION
Add SHACL shapes for the FNML part of the RML ontology:

- rmlf:ReturnMap
- rmlf:Execution
- rmlf:Input
- rmlf:ParameterMap

generate_shape.py takes all the separate shapes and combines it into a single shape for SHACL validators 'fnml.ttl'.